### PR TITLE
Update ld2410.rst

### DIFF
--- a/components/sensor/ld2410.rst
+++ b/components/sensor/ld2410.rst
@@ -498,13 +498,13 @@ For easy calibration process you can use the following custom manual card.
           - type: horizontal-stack
             cards:
               - type: entity
-                entity: 'sensor.DEVICE_distance_detection_cm'
+                entity: 'sensor.DEVICE_detection_distance'
                 name: distance
               - type: entity
-                entity: 'sensor.DEVICE_moving_distance_cm'
+                entity: 'sensor.DEVICE_moving_distance'
                 name: move
               - type: entity
-                entity: 'sensor.DEVICE_still_distance_cm'
+                entity: 'sensor.DEVICE_still_distance'
                 name: still
       - type: horizontal-stack
         cards:
@@ -517,7 +517,7 @@ For easy calibration process you can use the following custom manual card.
       - type: horizontal-stack
         cards:
           - type: entity
-            entity: 'binary_sensor.DEVICE_gpio_out_pin_presence'
+            entity: 'binary_sensor.DEVICE_out_pin_presence_status'
             name: gpio presence
             state_color: true
           - type: entity
@@ -525,11 +525,11 @@ For easy calibration process you can use the following custom manual card.
             name: presence
             state_color: true
           - type: entity
-            entity: 'binary_sensor.DEVICE_movement'
+            entity: 'binary_sensor.DEVICE_moving_target'
             name: movement
             state_color: true
           - type: entity
-            entity: 'binary_sensor.DEVICE_still'
+            entity: 'binary_sensor.DEVICE_still_target'
             name: still
             state_color: true
       - type: conditional


### PR DESCRIPTION
fix incorrect custom card entities

## Description: Fixes incorrect entity references for custom home assistant card in documentation


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
